### PR TITLE
chore: Global Exception Handler 생성

### DIFF
--- a/src/main/java/com/amcamp/global/common/response/GlobalResponse.java
+++ b/src/main/java/com/amcamp/global/common/response/GlobalResponse.java
@@ -1,9 +1,15 @@
 package com.amcamp.global.common.response;
 
+import com.amcamp.global.error.ErrorResponse;
+
 import java.time.LocalDateTime;
 
 public record GlobalResponse(boolean success, int status, Object data, LocalDateTime timestamp) {
     public static GlobalResponse success(int status, Object data) {
         return new GlobalResponse(true, status, data, LocalDateTime.now());
+    }
+
+    public static GlobalResponse fail(int status, ErrorResponse errorResponse) {
+        return new GlobalResponse(false, status, errorResponse, LocalDateTime.now());
     }
 }

--- a/src/main/java/com/amcamp/global/error/ErrorResponse.java
+++ b/src/main/java/com/amcamp/global/error/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.amcamp.global.error;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@ToString
+public class ErrorResponse {
+    private final HttpStatus status;
+    private final String message;
+
+    @Builder
+    public ErrorResponse(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/amcamp/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/amcamp/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.amcamp.global.error;
+
+import com.amcamp.global.common.response.GlobalResponse;
+import com.amcamp.global.error.exception.CustomException;
+import com.amcamp.global.error.exception.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<GlobalResponse> handleCustomException(CustomException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(errorCode.getHttpStatus())
+                .message(errorCode.getMessage())
+                .build();
+
+        final GlobalResponse response = GlobalResponse.
+                fail(errorCode.getHttpStatus().value(), errorResponse);
+
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(response);
+    }
+}

--- a/src/main/java/com/amcamp/global/error/exception/CustomException.java
+++ b/src/main/java/com/amcamp/global/error/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.amcamp.global.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.amcamp.global.error.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH INFO NOT FOUND"),
+    TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "FAIL_TO_VERIFY_TOKEN");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #13 

---
## 📌 작업 내용 및 특이사항

- GlobalExceptionHandler를 추가했습니다.
  - GlobalResponse가 반환타입인 에러 핸들러를 추가
- 커밋 메시지를 이슈와 연결하지 않도록 재작성했습니다.
  - 단일 커밋 메시지만 존재하도록 작성
  - 커밋 메시지에 브랜치 넘버를 명시하지 않음