### PR TITLE
feat: 소셜 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Custom ###
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,11 @@ dependencies {
 
     // Spring Cloud Open Feign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,12 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Spring Cloud
+    implementation platform("org.springframework.cloud:spring-cloud-dependencies:2024.0.0")
+
+    // Spring Cloud Open Feign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Oauth2 Jose
+    implementation 'org.springframework.security:spring-security-oauth2-jose'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/amcamp/domain/auth/api/AuthController.java
+++ b/src/main/java/com/amcamp/domain/auth/api/AuthController.java
@@ -3,7 +3,10 @@ package com.amcamp.domain.auth.api;
 import com.amcamp.domain.auth.application.AuthService;
 import com.amcamp.domain.auth.dto.request.AuthCodeRequest;
 import com.amcamp.domain.auth.dto.response.SocialLoginResponse;
+import com.amcamp.global.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,9 +18,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final CookieUtil cookieUtil;
 
     @PostMapping("/social-login")
-    public SocialLoginResponse memberSocialLogin(@RequestBody AuthCodeRequest request) {
-        return authService.socialLoginMember(request);
+    public ResponseEntity<SocialLoginResponse> memberSocialLogin(@RequestBody AuthCodeRequest request) {
+        SocialLoginResponse response = authService.socialLoginMember(request);
+
+        String refreshToken = response.refreshToken();
+        HttpHeaders headers = cookieUtil.generateRefreshTokenCookie(refreshToken);
+
+        return ResponseEntity.ok().headers(headers).body(response);
     }
 }

--- a/src/main/java/com/amcamp/domain/auth/api/AuthController.java
+++ b/src/main/java/com/amcamp/domain/auth/api/AuthController.java
@@ -1,0 +1,23 @@
+package com.amcamp.domain.auth.api;
+
+import com.amcamp.domain.auth.application.AuthService;
+import com.amcamp.domain.auth.dto.request.AuthCodeRequest;
+import com.amcamp.domain.auth.dto.response.SocialLoginResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/social-login")
+    public SocialLoginResponse memberSocialLogin(@RequestBody AuthCodeRequest request) {
+        return authService.socialLoginMember(request);
+    }
+}

--- a/src/main/java/com/amcamp/domain/auth/application/AuthService.java
+++ b/src/main/java/com/amcamp/domain/auth/application/AuthService.java
@@ -1,0 +1,58 @@
+package com.amcamp.domain.auth.application;
+
+import com.amcamp.domain.auth.dto.request.AuthCodeRequest;
+import com.amcamp.domain.auth.dto.response.IdTokenResponse;
+import com.amcamp.domain.auth.dto.response.SocialLoginResponse;
+import com.amcamp.domain.member.dao.MemberRepository;
+import com.amcamp.domain.member.domain.Member;
+import com.amcamp.domain.member.domain.OauthInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoService kakaoService;
+    private final JwtTokenService jwtTokenService;
+    private final IdTokenVerifier idTokenVerifier;
+    private final MemberRepository memberRepository;
+
+    public SocialLoginResponse socialLoginMember(AuthCodeRequest request) {
+        IdTokenResponse response = kakaoService.getIdToken(request.code());
+        String idToken = response.id_token();
+        OidcUser oidcUser = idTokenVerifier.getOidcUser(idToken);
+
+        Optional<Member> optionalMember = findByOidcUser(oidcUser);
+        Member member = optionalMember.orElseGet(() -> saveMember(oidcUser));
+
+        return getLoginResponse(member);
+    }
+
+    private SocialLoginResponse getLoginResponse(Member member) {
+        String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
+        String refreshToken = jwtTokenService.createRefreshToken(member.getId());
+        return SocialLoginResponse.of(accessToken, refreshToken);
+    }
+
+    private Optional<Member> findByOidcUser(OidcUser oidcUser) {
+        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
+        return memberRepository.findByOauthInfo(oauthInfo);
+    }
+
+    private Member saveMember(OidcUser oidcUser) {
+        OauthInfo oauthInfo = extractOauthInfo(oidcUser);
+        Member member = Member.createMember(oidcUser.getNickName(), oidcUser.getPicture(), oauthInfo);
+        return memberRepository.save(member);
+    }
+
+    private OauthInfo extractOauthInfo(OidcUser oidcUser) {
+        return OauthInfo.createOauthInfo(
+                oidcUser.getSubject(), oidcUser.getIssuer().toString());
+    }
+}

--- a/src/main/java/com/amcamp/domain/auth/application/IdTokenVerifier.java
+++ b/src/main/java/com/amcamp/domain/auth/application/IdTokenVerifier.java
@@ -1,0 +1,73 @@
+package com.amcamp.domain.auth.application;
+
+import com.amcamp.global.error.exception.CustomException;
+import com.amcamp.global.error.exception.ErrorCode;
+import com.amcamp.infra.config.oauth.KakaoProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class IdTokenVerifier {
+
+    private final KakaoProperties kakaoProperties;
+    private final JwtDecoder jwtDecoder = buildDecoder();
+
+    public OidcUser getOidcUser(String idToken) {
+        Jwt jwt = getJwt(idToken);
+        OidcIdToken oidcIdToken = getOidcIdToken(jwt);
+
+        validateAudience(oidcIdToken);
+        validateIssuer(oidcIdToken);
+        validateExpiresAt(oidcIdToken);
+
+        return new DefaultOidcUser(null, oidcIdToken);
+    }
+
+    private Jwt getJwt(String idToken) {
+        return jwtDecoder.decode(idToken);
+    }
+
+    private JwtDecoder buildDecoder() {
+        return NimbusJwtDecoder
+                .withJwkSetUri("https://kauth.kakao.com/.well-known/jwks.json")
+                .build();
+    }
+
+    private void validateAudience(OidcIdToken oidcIdToken) {
+        String idTokenAudience = oidcIdToken.getAudience().get(0);
+
+        if (idTokenAudience == null || !idTokenAudience.equals(kakaoProperties.clientId())) {
+            throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateIssuer(OidcIdToken oidcIdToken) {
+        String idTokenIssuer = oidcIdToken.getIssuer().toString();
+
+        if (idTokenIssuer == null || !idTokenIssuer.equals("https://kauth.kakao.com")) {
+            throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private void validateExpiresAt(OidcIdToken oidcIdToken) {
+        Instant expiresAt = oidcIdToken.getExpiresAt();
+
+        if (expiresAt == null || expiresAt.isBefore(Instant.now())) {
+            throw new CustomException(ErrorCode.ID_TOKEN_VERIFICATION_FAILED);
+        }
+    }
+
+    private OidcIdToken getOidcIdToken(Jwt jwt) {
+        return new OidcIdToken(
+                jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
+    }
+}

--- a/src/main/java/com/amcamp/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/amcamp/domain/auth/application/JwtTokenService.java
@@ -2,6 +2,7 @@ package com.amcamp.domain.auth.application;
 
 import com.amcamp.domain.auth.dao.RefreshTokenRepository;
 import com.amcamp.domain.auth.domain.RefreshToken;
+import com.amcamp.domain.auth.dto.AccessTokenDto;
 import com.amcamp.domain.member.domain.MemberRole;
 import com.amcamp.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,13 @@ public class JwtTokenService {
         refreshTokenRepository.save(refreshToken);
 
         return token;
+    }
+
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
+        try {
+            return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/amcamp/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/amcamp/domain/auth/application/JwtTokenService.java
@@ -1,0 +1,33 @@
+package com.amcamp.domain.auth.application;
+
+import com.amcamp.domain.auth.dao.RefreshTokenRepository;
+import com.amcamp.domain.auth.domain.RefreshToken;
+import com.amcamp.domain.member.domain.MemberRole;
+import com.amcamp.global.common.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String createAccessToken(Long memberId, MemberRole memberRole) {
+        return jwtUtil.generateAccessToken(memberId, memberRole);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        String token = jwtUtil.generateRefreshToken(memberId);
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(token)
+                        .ttl(jwtUtil.getRefreshTokenExpirationTime())
+                        .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return token;
+    }
+}

--- a/src/main/java/com/amcamp/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/amcamp/domain/auth/application/JwtTokenService.java
@@ -3,7 +3,7 @@ package com.amcamp.domain.auth.application;
 import com.amcamp.domain.auth.dao.RefreshTokenRepository;
 import com.amcamp.domain.auth.domain.RefreshToken;
 import com.amcamp.domain.member.domain.MemberRole;
-import com.amcamp.global.common.util.JwtUtil;
+import com.amcamp.global.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/amcamp/domain/auth/application/JwtTokenService.java
+++ b/src/main/java/com/amcamp/domain/auth/application/JwtTokenService.java
@@ -3,10 +3,14 @@ package com.amcamp.domain.auth.application;
 import com.amcamp.domain.auth.dao.RefreshTokenRepository;
 import com.amcamp.domain.auth.domain.RefreshToken;
 import com.amcamp.domain.auth.dto.AccessTokenDto;
+import com.amcamp.domain.auth.dto.RefreshTokenDto;
 import com.amcamp.domain.member.domain.MemberRole;
 import com.amcamp.global.util.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,8 +19,25 @@ public class JwtTokenService {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
+    public AccessTokenDto createAccessTokenDto(Long memberId, MemberRole memberRole) {
+        return jwtUtil.generateAccessTokenDto(memberId, memberRole);
+    }
+
     public String createAccessToken(Long memberId, MemberRole memberRole) {
         return jwtUtil.generateAccessToken(memberId, memberRole);
+    }
+
+    public RefreshTokenDto createRefreshTokenDto(Long memberId) {
+        RefreshTokenDto refreshTokenDto = jwtUtil.generateRefreshTokenDto(memberId);
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(refreshTokenDto.refreshTokenValue())
+                        .ttl(refreshTokenDto.ttl())
+                        .build();
+        refreshTokenRepository.save(refreshToken);
+
+        return refreshTokenDto;
     }
 
     public String createRefreshToken(Long memberId) {
@@ -38,5 +59,46 @@ public class JwtTokenService {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    public RefreshTokenDto retrieveRefreshToken(String refreshTokenValue) {
+        RefreshTokenDto refreshTokenDto = parseRefreshToken(refreshTokenValue);
+
+        if (refreshTokenDto == null) {
+            return null;
+        }
+
+        Optional<RefreshToken> refreshToken = getRefreshToken(refreshTokenDto.memberId());
+
+        if (refreshToken.isPresent() &&
+                refreshTokenDto.refreshTokenValue().equals(refreshToken.get().getToken())) {
+            return refreshTokenDto;
+        }
+
+        return null;
+    }
+
+    public AccessTokenDto reissueAccessTokenIfExpired(String accessTokenValue) {
+        try {
+            jwtUtil.parseAccessToken(accessTokenValue);
+            return null;
+        } catch (ExpiredJwtException e) {
+            Long memberId = Long.parseLong(e.getClaims().getSubject());
+            MemberRole memberRole = MemberRole.valueOf(e.getClaims().get("role", String.class));
+
+            return createAccessTokenDto(memberId, memberRole);
+        }
+    }
+
+    private RefreshTokenDto parseRefreshToken(String refreshTokenValue) {
+        try {
+            return jwtUtil.parseRefreshToken(refreshTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Optional<RefreshToken> getRefreshToken(Long memberId) {
+        return refreshTokenRepository.findById(memberId);
     }
 }

--- a/src/main/java/com/amcamp/domain/auth/application/KakaoService.java
+++ b/src/main/java/com/amcamp/domain/auth/application/KakaoService.java
@@ -1,0 +1,24 @@
+package com.amcamp.domain.auth.application;
+
+import com.amcamp.domain.auth.dto.response.IdTokenResponse;
+import com.amcamp.infra.config.feign.KakaoOauthClient;
+import com.amcamp.infra.config.oauth.KakaoProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final KakaoOauthClient kakaoOauthClient;
+    private final KakaoProperties kakaoProperties;
+
+    public IdTokenResponse getIdToken(String code) {
+        return kakaoOauthClient.getIdToken(
+                kakaoProperties.grantType(),
+                kakaoProperties.clientId(),
+                kakaoProperties.redirectUri(),
+                code,
+                kakaoProperties.clientSecret());
+    }
+}

--- a/src/main/java/com/amcamp/domain/auth/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/amcamp/domain/auth/dao/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.amcamp.domain.auth.dao;
+
+import com.amcamp.domain.auth.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/amcamp/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/amcamp/domain/auth/domain/RefreshToken.java
@@ -1,0 +1,27 @@
+package com.amcamp.domain.auth.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+    @Id
+    private Long memberId;
+
+    private String token;
+
+    @TimeToLive
+    private long ttl;
+
+    @Builder
+    private RefreshToken(Long memberId, String token, long ttl) {
+        this.memberId = memberId;
+        this.token = token;
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/com/amcamp/domain/auth/dto/AccessTokenDto.java
+++ b/src/main/java/com/amcamp/domain/auth/dto/AccessTokenDto.java
@@ -1,0 +1,9 @@
+package com.amcamp.domain.auth.dto;
+
+import com.amcamp.domain.member.domain.MemberRole;
+
+public record AccessTokenDto(Long memberId, MemberRole role, String accessTokenValue) {
+    public static AccessTokenDto of(Long memberId, MemberRole role, String accessTokenValue) {
+        return new AccessTokenDto(memberId, role, accessTokenValue);
+    }
+}

--- a/src/main/java/com/amcamp/domain/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/com/amcamp/domain/auth/dto/RefreshTokenDto.java
@@ -1,0 +1,7 @@
+package com.amcamp.domain.auth.dto;
+
+public record RefreshTokenDto(Long memberId, String refreshTokenValue, Long ttl) {
+    public static RefreshTokenDto of(Long memberId, String refreshTokenValue, Long ttl) {
+        return new RefreshTokenDto(memberId, refreshTokenValue, ttl);
+    }
+}

--- a/src/main/java/com/amcamp/domain/auth/dto/request/AuthCodeRequest.java
+++ b/src/main/java/com/amcamp/domain/auth/dto/request/AuthCodeRequest.java
@@ -1,0 +1,4 @@
+package com.amcamp.domain.auth.dto.request;
+
+public record AuthCodeRequest(String code) {
+}

--- a/src/main/java/com/amcamp/domain/auth/dto/response/IdTokenResponse.java
+++ b/src/main/java/com/amcamp/domain/auth/dto/response/IdTokenResponse.java
@@ -1,0 +1,4 @@
+package com.amcamp.domain.auth.dto.response;
+
+public record IdTokenResponse(String id_token) {
+}

--- a/src/main/java/com/amcamp/domain/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/amcamp/domain/auth/dto/response/SocialLoginResponse.java
@@ -1,6 +1,8 @@
 package com.amcamp.domain.auth.dto.response;
 
-public record SocialLoginResponse(String accessToken, String refreshToken) {
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public record SocialLoginResponse(String accessToken, @JsonIgnore String refreshToken) {
     public static SocialLoginResponse of(String accessToken, String refreshToken) {
         return new SocialLoginResponse(accessToken, refreshToken);
     }

--- a/src/main/java/com/amcamp/domain/auth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/amcamp/domain/auth/dto/response/SocialLoginResponse.java
@@ -1,0 +1,7 @@
+package com.amcamp.domain.auth.dto.response;
+
+public record SocialLoginResponse(String accessToken, String refreshToken) {
+    public static SocialLoginResponse of(String accessToken, String refreshToken) {
+        return new SocialLoginResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/amcamp/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/amcamp/domain/member/dao/MemberRepository.java
@@ -1,7 +1,11 @@
 package com.amcamp.domain.member.dao;
 
 import com.amcamp.domain.member.domain.Member;
+import com.amcamp.domain.member.domain.OauthInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByOauthInfo(OauthInfo oauthInfo);
 }

--- a/src/main/java/com/amcamp/global/common/config/feign/FeignConfig.java
+++ b/src/main/java/com/amcamp/global/common/config/feign/FeignConfig.java
@@ -1,0 +1,17 @@
+package com.amcamp.global.common.config.feign;
+
+import feign.RequestInterceptor;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "com.amcamp.infra.config.feign")
+public class FeignConfig {
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> requestTemplate
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+    }
+}

--- a/src/main/java/com/amcamp/global/common/util/JwtUtil.java
+++ b/src/main/java/com/amcamp/global/common/util/JwtUtil.java
@@ -30,6 +30,10 @@ public class JwtUtil {
         return buildRefreshToken(memberId, issuedAt, expiredAt);
     }
 
+    public long getRefreshTokenExpirationTime() {
+        return jwtProperties.refreshTokenExpirationTime();
+    }
+
     private Key getAccessTokenKey() {
         return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
     }

--- a/src/main/java/com/amcamp/global/common/util/JwtUtil.java
+++ b/src/main/java/com/amcamp/global/common/util/JwtUtil.java
@@ -1,0 +1,63 @@
+package com.amcamp.global.common.util;
+
+import com.amcamp.domain.member.domain.MemberRole;
+import com.amcamp.infra.config.jwt.JwtProperties;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtProperties jwtProperties;
+
+    public String generateAccessToken(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+    }
+
+    public String generateRefreshToken(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+    }
+
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.refreshTokenSecret().getBytes());
+    }
+
+    private String buildAccessToken(
+            Long memberId, MemberRole memberRole, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(memberId.toString())
+                .claim("role", memberRole.name())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getAccessTokenKey())
+                .compact();
+    }
+
+    private String buildRefreshToken(
+            Long memberId, Date issuedAt, Date expiredAt) {
+        return Jwts.builder()
+                .setIssuer(jwtProperties.issuer())
+                .setSubject(memberId.toString())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRefreshTokenKey())
+                .compact();
+    }
+}

--- a/src/main/java/com/amcamp/global/common/util/JwtUtil.java
+++ b/src/main/java/com/amcamp/global/common/util/JwtUtil.java
@@ -1,7 +1,12 @@
 package com.amcamp.global.common.util;
 
+import com.amcamp.domain.auth.dto.AccessTokenDto;
+import com.amcamp.domain.auth.dto.RefreshTokenDto;
 import com.amcamp.domain.member.domain.MemberRole;
 import com.amcamp.infra.config.jwt.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +21,58 @@ public class JwtUtil {
 
     private final JwtProperties jwtProperties;
 
+    public AccessTokenDto generateAccessTokenDto(Long memberId, MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String tokenValue = buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+        return new AccessTokenDto(memberId, memberRole, tokenValue);
+    }
+
     public String generateAccessToken(Long memberId, MemberRole memberRole) {
         Date issuedAt = new Date();
         Date expiredAt =
                 new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
         return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+    }
+
+    public RefreshTokenDto generateRefreshTokenDto(Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        String tokenValue = buildRefreshToken(memberId, issuedAt, expiredAt);
+        return new RefreshTokenDto(
+                memberId, tokenValue, jwtProperties.refreshTokenExpirationTime());
+    }
+
+    public AccessTokenDto parseAccessToken(String accessTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(accessTokenValue, getAccessTokenKey());
+
+            return AccessTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    MemberRole.valueOf(claims.getBody().get("role", String.class)),
+                    accessTokenValue);
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto parseRefreshToken(String refreshTokenValue) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(refreshTokenValue, getRefreshTokenKey());
+
+            return RefreshTokenDto.of(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    refreshTokenValue,
+                    jwtProperties.refreshTokenExpirationTime());
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public String generateRefreshToken(Long memberId) {
@@ -63,5 +115,13 @@ public class JwtUtil {
                 .setExpiration(expiredAt)
                 .signWith(getRefreshTokenKey())
                 .compact();
+    }
+
+    private Jws<Claims> getClaims(String token, Key key) {
+        return Jwts.parserBuilder()
+                .requireIssuer(jwtProperties.issuer())
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
     }
 }

--- a/src/main/java/com/amcamp/global/config/feign/FeignConfig.java
+++ b/src/main/java/com/amcamp/global/config/feign/FeignConfig.java
@@ -1,4 +1,4 @@
-package com.amcamp.global.common.config.feign;
+package com.amcamp.global.config.feign;
 
 import feign.RequestInterceptor;
 import org.springframework.cloud.openfeign.EnableFeignClients;

--- a/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package com.amcamp.global.config.security;
 
 import com.amcamp.domain.auth.application.JwtTokenService;
 import com.amcamp.global.security.JwtAuthenticationFilter;
+import com.amcamp.global.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +25,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class WebSecurityConfig {
 
     private final JwtTokenService jwtTokenService;
+    private final CookieUtil cookieUtil;
 
     @Bean
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -43,7 +45,7 @@ public class WebSecurityConfig {
                                 .authenticated());
 
         http.addFilterBefore(
-                jwtAuthenticationFilter(jwtTokenService), UsernamePasswordAuthenticationFilter.class);
+                jwtAuthenticationFilter(jwtTokenService, cookieUtil), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -63,7 +65,7 @@ public class WebSecurityConfig {
     }
 
     @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtTokenService jwtTokenService) {
-        return new JwtAuthenticationFilter(jwtTokenService);
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtTokenService jwtTokenService, CookieUtil cookieUtil) {
+        return new JwtAuthenticationFilter(jwtTokenService, cookieUtil);
     }
 }

--- a/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
@@ -1,5 +1,8 @@
 package com.amcamp.global.config.security;
 
+import com.amcamp.domain.auth.application.JwtTokenService;
+import com.amcamp.global.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -7,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -15,7 +19,10 @@ import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class WebSecurityConfig {
+
+    private final JwtTokenService jwtTokenService;
 
     @Bean
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
@@ -34,6 +41,9 @@ public class WebSecurityConfig {
                                 .anyRequest()
                                 .authenticated());
 
+        http.addFilterBefore(
+                jwtAuthenticationFilter(jwtTokenService), UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 
@@ -48,5 +58,10 @@ public class WebSecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtTokenService jwtTokenService) {
+        return new JwtAuthenticationFilter(jwtTokenService);
     }
 }

--- a/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
@@ -54,6 +55,7 @@ public class WebSecurityConfig {
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);
+        configuration.addExposedHeader(SET_COOKIE);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/amcamp/global/config/security/WebSecurityConfig.java
@@ -1,4 +1,4 @@
-package com.amcamp.global.common.config.security;
+package com.amcamp.global.config.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH INFO NOT FOUND"),
-    TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "FAIL_TO_VERIFY_TOKEN");
+    ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/amcamp/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/amcamp/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package com.amcamp.global.security;
+
+import com.amcamp.domain.auth.application.JwtTokenService;
+import com.amcamp.domain.auth.dto.AccessTokenDto;
+import com.amcamp.domain.member.domain.MemberRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenService jwtTokenService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
+
+        if (accessTokenHeaderValue != null) {
+            AccessTokenDto accessTokenDto =
+                    jwtTokenService.retrieveAccessToken(accessTokenHeaderValue);
+
+            // AT가 유효하면 통과
+            if (accessTokenDto != null) {
+                setAuthenticationToken(accessTokenDto.memberId(), accessTokenDto.role());
+                filterChain.doFilter(request, response);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthenticationToken(Long memberId, MemberRole role) {
+        UserDetails userDetails =
+                User.withUsername(memberId.toString())
+                        .authorities(role.toString())
+                        .password("")
+                        .build();
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    private String extractAccessTokenFromHeader(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.replace("Bearer ", "");
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/amcamp/global/util/CookieUtil.java
+++ b/src/main/java/com/amcamp/global/util/CookieUtil.java
@@ -1,0 +1,25 @@
+package com.amcamp.global.util;
+
+import org.springframework.boot.web.server.Cookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public HttpHeaders generateRefreshTokenCookie(String refreshToken) {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from("refreshToken", refreshToken)
+                        .path("/")
+                        .secure(false)
+                        .sameSite(Cookie.SameSite.NONE.attributeValue())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
+}

--- a/src/main/java/com/amcamp/global/util/JwtUtil.java
+++ b/src/main/java/com/amcamp/global/util/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.amcamp.global.common.util;
+package com.amcamp.global.util;
 
 import com.amcamp.domain.auth.dto.AccessTokenDto;
 import com.amcamp.domain.auth.dto.RefreshTokenDto;

--- a/src/main/java/com/amcamp/infra/config/feign/KakaoOauthClient.java
+++ b/src/main/java/com/amcamp/infra/config/feign/KakaoOauthClient.java
@@ -1,0 +1,22 @@
+package com.amcamp.infra.config.feign;
+
+
+import com.amcamp.domain.auth.dto.response.IdTokenResponse;
+import com.amcamp.global.common.config.feign.FeignConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+        name = "kakaoOauthClient",
+        url = "https://kauth.kakao.com",
+        configuration = FeignConfig.class)
+public interface KakaoOauthClient {
+    @PostMapping(value = "/oauth/token")
+    IdTokenResponse getIdToken(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("code") String code,
+            @RequestParam("client_secret") String clientSecret);
+}

--- a/src/main/java/com/amcamp/infra/config/feign/KakaoOauthClient.java
+++ b/src/main/java/com/amcamp/infra/config/feign/KakaoOauthClient.java
@@ -2,7 +2,7 @@ package com.amcamp.infra.config.feign;
 
 
 import com.amcamp.domain.auth.dto.response.IdTokenResponse;
-import com.amcamp.global.common.config.feign.FeignConfig;
+import com.amcamp.global.config.feign.FeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/amcamp/infra/config/jwt/JwtProperties.java
+++ b/src/main/java/com/amcamp/infra/config/jwt/JwtProperties.java
@@ -1,0 +1,18 @@
+package com.amcamp.infra.config.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String accessTokenSecret,
+        String refreshTokenSecret,
+        Long accessTokenExpirationTime,
+        Long refreshTokenExpirationTime,
+        String issuer) {
+    public Long accessTokenExpirationMilliTime() {
+        return accessTokenExpirationTime * 1000;
+    }
+    public Long refreshTokenExpirationMilliTime() {
+        return refreshTokenExpirationTime * 1000;
+    }
+}

--- a/src/main/java/com/amcamp/infra/config/oauth/KakaoProperties.java
+++ b/src/main/java/com/amcamp/infra/config/oauth/KakaoProperties.java
@@ -1,0 +1,11 @@
+package com.amcamp.infra.config.oauth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoProperties(
+        String clientId,
+        String clientSecret,
+        String redirectUri,
+        String grantType) {
+}

--- a/src/main/java/com/amcamp/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/amcamp/infra/config/properties/PropertiesConfig.java
@@ -1,5 +1,6 @@
 package com.amcamp.infra.config.properties;
 
+import com.amcamp.infra.config.jwt.JwtProperties;
 import com.amcamp.infra.config.oauth.KakaoProperties;
 import com.amcamp.infra.config.redis.RedisProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -7,7 +8,8 @@ import org.springframework.context.annotation.Configuration;
 
 @EnableConfigurationProperties({
         RedisProperties.class,
-        KakaoProperties.class
+        KakaoProperties.class,
+        JwtProperties.class
 })
 @Configuration
 public class PropertiesConfig {

--- a/src/main/java/com/amcamp/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/amcamp/infra/config/properties/PropertiesConfig.java
@@ -1,11 +1,13 @@
 package com.amcamp.infra.config.properties;
 
+import com.amcamp.infra.config.oauth.KakaoProperties;
 import com.amcamp.infra.config.redis.RedisProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @EnableConfigurationProperties({
-        RedisProperties.class
+        RedisProperties.class,
+        KakaoProperties.class
 })
 @Configuration
 public class PropertiesConfig {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,15 @@
 spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:tcp://localhost/~/syncfit
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
   data:
     redis:
       host: ${REDIS_HOST:localhost}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,10 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD:}
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+    grant-type: ${KAKAO_CLIENT_GRANT_TYPE}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,10 @@ oauth:
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI}
     grant-type: ${KAKAO_CLIENT_GRANT_TYPE}
+
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME:7200}
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME:172800}
+  issuer: ${JWT_ISSUER}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #18 

---
## 📌 작업 내용 및 특이사항

- OIDC 인증을 통한 카카오 소셜 로그인을 구현하였습니다.
  - 카카오 인증서버로부터 ID토큰을 발급받기 위해 OpenFeign을 사용하였습니다.
  - 발급받은 ID 토큰을 검증하는 로직을 추가하였습니다.
  - 소셜 로그인 성공 시 백엔드 서버에서 엑세스 토큰과 리프레시 토큰을 발급해줍니다.
- 쿠키와 redis를 사용하여 리프레시 토큰을 관리합니다.
- JWT 인증 필터를 추가하였습니다. 
  - 헤더에 담겨 보내진 엑세스 토큰이 유효하지 않고 쿠키에 담긴 리프레시 토큰이 유효하다면 토큰을 재발급해줍니다. 