### PR TITLE
feat: 로그인한 멤버 조회 유틸리티 구현

### DIFF
--- a/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
@@ -9,6 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
+    AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "사용자 인증 정보를 찾을 수 없습니다. 올바른 토큰으로 요청해주세요."),
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/amcamp/global/util/MemberUtil.java
+++ b/src/main/java/com/amcamp/global/util/MemberUtil.java
@@ -1,0 +1,33 @@
+package com.amcamp.global.util;
+
+import com.amcamp.domain.member.dao.MemberRepository;
+import com.amcamp.domain.member.domain.Member;
+import com.amcamp.global.error.exception.CustomException;
+import com.amcamp.global.error.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberUtil {
+
+    private final MemberRepository memberRepository;
+
+    public Member getCurrentMember() {
+        return memberRepository
+                .findById(getCurrentMemberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.AUTH_NOT_FOUND);
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #20 

---
## 📌 작업 내용 및 특이사항

- MemberUtil 구현
  - SecurityContext에서 로그인한 멤버 정보를 가져오는 유틸리티를 구현하였습니다.
  - 서비스 레이어에서 주입받아서 사용하시기 바랍니다.