### PR TITLE
feat: 로그아웃 구현

### DIFF
--- a/src/main/java/com/amcamp/domain/member/api/MemberController.java
+++ b/src/main/java/com/amcamp/domain/member/api/MemberController.java
@@ -2,8 +2,11 @@ package com.amcamp.domain.member.api;
 
 import com.amcamp.domain.member.application.MemberService;
 import com.amcamp.domain.member.dto.response.MemberInfoResponse;
+import com.amcamp.global.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,6 +16,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final CookieUtil cookieUtil;
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> memberLogout() {
+        memberService.logoutMember();
+        return ResponseEntity.ok().headers(cookieUtil.deleteRefreshTokenCookie()).build();
+    }
 
     @GetMapping("/me")
     public MemberInfoResponse memberInfo() {

--- a/src/main/java/com/amcamp/domain/member/application/MemberService.java
+++ b/src/main/java/com/amcamp/domain/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package com.amcamp.domain.member.application;
 
+import com.amcamp.domain.auth.dao.RefreshTokenRepository;
 import com.amcamp.domain.member.domain.Member;
 import com.amcamp.domain.member.dto.response.MemberInfoResponse;
 import com.amcamp.global.util.MemberUtil;
@@ -13,6 +14,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberUtil memberUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void logoutMember() {
+        Member currentMember = memberUtil.getCurrentMember();
+        refreshTokenRepository
+                .findById(currentMember.getId())
+                .ifPresent(refreshTokenRepository::delete);
+    }
 
     @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfo() {

--- a/src/main/java/com/amcamp/global/util/CookieUtil.java
+++ b/src/main/java/com/amcamp/global/util/CookieUtil.java
@@ -22,4 +22,20 @@ public class CookieUtil {
 
         return headers;
     }
+
+    public HttpHeaders deleteRefreshTokenCookie() {
+        ResponseCookie refreshTokenCookie =
+                ResponseCookie.from("refreshToken", "")
+                        .path("/")
+                        .maxAge(0)
+                        .secure(false)
+                        .sameSite(Cookie.SameSite.NONE.attributeValue())
+                        .httpOnly(true)
+                        .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return headers;
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #28 

---
## 📌 작업 내용 및 특이사항

- 회원의 로그아웃 기능을 구현하였습니다.
  - 로그아웃 시 Redis에 저장되어 있는 리프레시 토큰과 쿠키에 담긴 토큰이 삭제됩니다.