### PR TITLE
feat: Spotify 곡 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 
     // MySQL
     implementation 'mysql:mysql-connector-java:8.0.33'
+
+    // Spotify
+    implementation 'se.michaelthelin.spotify:spotify-web-api-java:8.4.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/amcamp/domain/spotify/api/SpotifyController.java
+++ b/src/main/java/com/amcamp/domain/spotify/api/SpotifyController.java
@@ -1,0 +1,24 @@
+package com.amcamp.domain.spotify.api;
+
+import com.amcamp.domain.spotify.application.SpotifyService;
+import com.amcamp.domain.spotify.dto.response.SpotifySearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/music")
+public class SpotifyController {
+
+    private final SpotifyService spotifyService;
+
+    @GetMapping("/search")
+    public List<SpotifySearchResponse> searchSpotify(@RequestParam List<String> genres) {
+        return spotifyService.searchByGenre(genres);
+    }
+}

--- a/src/main/java/com/amcamp/domain/spotify/application/SpotifyService.java
+++ b/src/main/java/com/amcamp/domain/spotify/application/SpotifyService.java
@@ -1,0 +1,89 @@
+package com.amcamp.domain.spotify.application;
+
+import com.amcamp.domain.spotify.dto.response.SpotifySearchResponse;
+import com.amcamp.global.error.exception.CustomException;
+import com.amcamp.global.error.exception.ErrorCode;
+import com.amcamp.global.util.MemberUtil;
+import com.amcamp.infra.config.spotify.SpotifyConfig;
+import lombok.RequiredArgsConstructor;
+import org.apache.hc.core5.http.ParseException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.specification.*;
+import se.michaelthelin.spotify.requests.data.search.simplified.SearchTracksRequest;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.neovisionaries.i18n.CountryCode.KR;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class SpotifyService {
+
+    private final SpotifyConfig spotifyConfig;
+    private final MemberUtil memberUtil;
+
+    public List<SpotifySearchResponse> searchByGenre(List<String> genres) {
+        memberUtil.getCurrentMember();
+
+        Track[] tracks = getTrackInfoByGenre(genres);
+
+        Set<String> uniqueTrackTitles = new HashSet<>();
+        List<SpotifySearchResponse> list = new ArrayList<>();
+
+        Arrays.stream(tracks)
+                .map(this::getTrackData)
+                .distinct()
+                .filter(trackData -> uniqueTrackTitles.add(trackData.title()))
+                .forEach(list::add);
+
+        return list;
+    }
+
+    /*
+     * 장르에 따른 검색 결과를 반환합니다.
+     */
+    public Track[] getTrackInfoByGenre(List<String> genres) {
+        try {
+            SpotifyApi spotifyApi = new SpotifyApi.Builder()
+                    .setAccessToken(spotifyConfig.generateAccessToken())
+                    .build();
+
+            String genreQuery = genres.stream()
+                    .map(genre -> "genre:" + genre)
+                    .collect(Collectors.joining(" OR "));
+
+            String query = genreQuery + " year:2024-2025";
+
+            SearchTracksRequest searchTrackRequest = spotifyApi.searchTracks(query)
+                    .market(KR)
+                    .limit(10)
+                    .build();
+
+            Paging<Track> searchResult = searchTrackRequest.execute();
+
+            return searchResult.getItems();
+        } catch (IOException | ParseException | SpotifyWebApiException e) {
+            throw new CustomException(ErrorCode.SPOTIFY_EXCEPTION);
+        }
+    }
+
+    private SpotifySearchResponse getTrackData(Track track) {
+        ArtistSimplified[] artists = track.getArtists();
+        String artistName = artists[0].getName();
+
+        AlbumSimplified album = track.getAlbum();
+        String albumName = album.getName();
+
+        Image[] images = album.getImages();
+        String imageUrl = (images.length > 0) ? images[0].getUrl() : "NO_IMAGE";
+
+        return SpotifySearchResponse.of(artistName, track.getName(), albumName, imageUrl);
+    }
+}
+

--- a/src/main/java/com/amcamp/domain/spotify/dto/response/SpotifySearchResponse.java
+++ b/src/main/java/com/amcamp/domain/spotify/dto/response/SpotifySearchResponse.java
@@ -1,0 +1,7 @@
+package com.amcamp.domain.spotify.dto.response;
+
+public record SpotifySearchResponse(String artistName, String title, String albumName, String imageUrl) {
+    public static SpotifySearchResponse of(String artistName, String title, String albumName, String imageUrl) {
+        return new SpotifySearchResponse(artistName, title, albumName, imageUrl);
+    }
+}

--- a/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "사용자 인증 정보를 찾을 수 없습니다. 올바른 토큰으로 요청해주세요."),
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+
+    SPOTIFY_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "스포티파이 라이브러리 사용 중 예외가 발생했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/amcamp/infra/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/amcamp/infra/config/properties/PropertiesConfig.java
@@ -4,6 +4,7 @@ import com.amcamp.infra.config.chat.ChatProperties;
 import com.amcamp.infra.config.jwt.JwtProperties;
 import com.amcamp.infra.config.oauth.KakaoProperties;
 import com.amcamp.infra.config.redis.RedisProperties;
+import com.amcamp.infra.config.spotify.SpotifyProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
         KakaoProperties.class,
         JwtProperties.class,
         ChatProperties.class,
+        SpotifyProperties.class,
 })
 @Configuration
 public class PropertiesConfig {

--- a/src/main/java/com/amcamp/infra/config/spotify/SpotifyConfig.java
+++ b/src/main/java/com/amcamp/infra/config/spotify/SpotifyConfig.java
@@ -1,0 +1,40 @@
+package com.amcamp.infra.config.spotify;
+
+import com.amcamp.global.error.exception.CustomException;
+import com.amcamp.global.error.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.core5.http.ParseException;
+import org.springframework.stereotype.Component;
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
+import se.michaelthelin.spotify.requests.authorization.client_credentials.ClientCredentialsRequest;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class SpotifyConfig {
+
+    private final SpotifyApi spotifyApi;
+
+    private SpotifyConfig(SpotifyProperties spotifyProperties) {
+        this.spotifyApi =
+                new SpotifyApi.Builder()
+                        .setClientId(spotifyProperties.clientId())
+                        .setClientSecret(spotifyProperties.clientSecret())
+                        .build();
+    }
+
+    public String generateAccessToken() {
+        ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
+        try {
+            final ClientCredentials clientCredentials = clientCredentialsRequest.execute();
+            spotifyApi.setAccessToken(clientCredentials.getAccessToken());
+            return spotifyApi.getAccessToken();
+        } catch (IOException | SpotifyWebApiException | ParseException e) {
+            log.error(e.getMessage());
+            throw new CustomException(ErrorCode.SPOTIFY_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/com/amcamp/infra/config/spotify/SpotifyProperties.java
+++ b/src/main/java/com/amcamp/infra/config/spotify/SpotifyProperties.java
@@ -1,0 +1,7 @@
+package com.amcamp.infra.config.spotify;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spotify")
+public record SpotifyProperties(String clientId, String clientSecret) {
+}

--- a/src/main/resources/application-spotify.yml
+++ b/src/main/resources/application-spotify.yml
@@ -1,0 +1,7 @@
+spring:
+  config:
+    activate:
+      on-profile: "spotify"
+spotify:
+  client-id: ${SPOTIFY_CLIENT_ID}
+  client-secret: ${SPOTIFY_CLIENT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,4 @@ spring:
       - security
       - redis
       - gemini
+      - spotify


### PR DESCRIPTION
## 🌱 관련 이슈

- close #25 

---
## 📌 작업 내용 및 특이사항

- 장르 기반 Spotify 음악 검색 기능을 구현하였습니다.
  - 각 장르별 2024~2025년에 발매된 최대 3곡을 검색합니다.
  - 동일한 곡 제목은 중복 제거했습니다.
  - 추천 곡은 최대 10곡까지 제공됩니다.