### PR TITLE
feat: 트랙 추가, 삭제, 조회 구현

### DIFF
--- a/src/main/java/com/amcamp/domain/track/api/TrackController.java
+++ b/src/main/java/com/amcamp/domain/track/api/TrackController.java
@@ -5,10 +5,7 @@ import com.amcamp.domain.track.dto.request.TrackCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,5 +20,11 @@ public class TrackController {
     public ResponseEntity<Void> trackCreate(@RequestBody List<TrackCreateRequest> request) {
         trackService.createTrack(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{trackId}")
+    public ResponseEntity<Void> trackDelete(@PathVariable Long trackId) {
+        trackService.deleteTrack(trackId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/amcamp/domain/track/api/TrackController.java
+++ b/src/main/java/com/amcamp/domain/track/api/TrackController.java
@@ -1,0 +1,26 @@
+package com.amcamp.domain.track.api;
+
+import com.amcamp.domain.track.application.TrackService;
+import com.amcamp.domain.track.dto.request.TrackCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tracks")
+public class TrackController {
+
+    private final TrackService trackService;
+
+    @PostMapping
+    public ResponseEntity<Void> trackCreate(@RequestBody List<TrackCreateRequest> request) {
+        trackService.createTrack(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/amcamp/domain/track/api/TrackController.java
+++ b/src/main/java/com/amcamp/domain/track/api/TrackController.java
@@ -3,6 +3,7 @@ package com.amcamp.domain.track.api;
 import com.amcamp.domain.track.application.TrackService;
 import com.amcamp.domain.track.dto.request.TrackCreateRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +22,6 @@ public class TrackController {
     @PostMapping
     public ResponseEntity<Void> trackCreate(@RequestBody List<TrackCreateRequest> request) {
         trackService.createTrack(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/amcamp/domain/track/api/TrackController.java
+++ b/src/main/java/com/amcamp/domain/track/api/TrackController.java
@@ -2,6 +2,7 @@ package com.amcamp.domain.track.api;
 
 import com.amcamp.domain.track.application.TrackService;
 import com.amcamp.domain.track.dto.request.TrackCreateRequest;
+import com.amcamp.domain.track.dto.response.TrackInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,5 +27,10 @@ public class TrackController {
     public ResponseEntity<Void> trackDelete(@PathVariable Long trackId) {
         trackService.deleteTrack(trackId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{wishlistId}")
+    public List<TrackInfoResponse> trackFindAll(@PathVariable Long wishlistId) {
+        return trackService.findAllTrack(wishlistId);
     }
 }

--- a/src/main/java/com/amcamp/domain/track/application/TrackService.java
+++ b/src/main/java/com/amcamp/domain/track/application/TrackService.java
@@ -4,6 +4,7 @@ import com.amcamp.domain.member.domain.Member;
 import com.amcamp.domain.track.dao.TrackRepository;
 import com.amcamp.domain.track.domain.Track;
 import com.amcamp.domain.track.dto.request.TrackCreateRequest;
+import com.amcamp.domain.track.dto.response.TrackInfoResponse;
 import com.amcamp.domain.wishlist.dao.WishlistRepository;
 import com.amcamp.domain.wishlist.domain.Wishlist;
 import com.amcamp.global.error.exception.CustomException;
@@ -46,6 +47,19 @@ public class TrackService {
         validateTrackMemberMismatch(track, currentMember);
 
         trackRepository.deleteById(trackId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TrackInfoResponse> findAllTrack(Long wishlistId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Wishlist wishlist = findWishlistById(wishlistId);
+
+        validateWishlistMemberMismatch(wishlist, currentMember);
+
+        return trackRepository.findAllByWishlistId(wishlist.getId())
+                .stream()
+                .map(TrackInfoResponse::from)
+                .toList();
     }
 
     private Wishlist findWishlistById(Long wishlistId) {

--- a/src/main/java/com/amcamp/domain/track/application/TrackService.java
+++ b/src/main/java/com/amcamp/domain/track/application/TrackService.java
@@ -1,0 +1,52 @@
+package com.amcamp.domain.track.application;
+
+import com.amcamp.domain.member.domain.Member;
+import com.amcamp.domain.track.dao.TrackRepository;
+import com.amcamp.domain.track.domain.Track;
+import com.amcamp.domain.track.dto.request.TrackCreateRequest;
+import com.amcamp.domain.wishlist.dao.WishlistRepository;
+import com.amcamp.domain.wishlist.domain.Wishlist;
+import com.amcamp.global.error.exception.CustomException;
+import com.amcamp.global.error.exception.ErrorCode;
+import com.amcamp.global.util.MemberUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class TrackService {
+
+    private final MemberUtil memberUtil;
+    private final WishlistRepository wishlistRepository;
+    private final TrackRepository trackRepository;
+
+    public void createTrack(List<TrackCreateRequest> requests) {
+        final Member currentMember = memberUtil.getCurrentMember();
+
+        List<Track> tracks = requests.stream()
+                .map(request -> {
+                    Wishlist wishlist = findWishlistById(request.wishlistId());
+                    validateWishlistMemberMismatch(wishlist, currentMember);
+                    return Track.createTrack(
+                            request.artistName(), request.title(), request.albumName(), request.imageUrl(), wishlist);
+                })
+                .toList();
+
+        trackRepository.saveAll(tracks);
+    }
+
+    private Wishlist findWishlistById(Long wishlistId) {
+        return wishlistRepository.findById(wishlistId)
+                .orElseThrow(() -> new CustomException(ErrorCode.WISHLIST_NOT_FOUND));
+    }
+
+    private void validateWishlistMemberMismatch(Wishlist wishlist, Member member) {
+        if (!wishlist.getMember().getId().equals(member.getId())) {
+            throw new CustomException(ErrorCode.WISHLIST_MEMBER_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/amcamp/domain/track/application/TrackService.java
+++ b/src/main/java/com/amcamp/domain/track/application/TrackService.java
@@ -39,6 +39,15 @@ public class TrackService {
         trackRepository.saveAll(tracks);
     }
 
+    public void deleteTrack(Long trackId) {
+        final Member currentMember = memberUtil.getCurrentMember();
+        final Track track = findTrackById(trackId);
+
+        validateTrackMemberMismatch(track, currentMember);
+
+        trackRepository.deleteById(trackId);
+    }
+
     private Wishlist findWishlistById(Long wishlistId) {
         return wishlistRepository.findById(wishlistId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WISHLIST_NOT_FOUND));
@@ -47,6 +56,17 @@ public class TrackService {
     private void validateWishlistMemberMismatch(Wishlist wishlist, Member member) {
         if (!wishlist.getMember().getId().equals(member.getId())) {
             throw new CustomException(ErrorCode.WISHLIST_MEMBER_MISMATCH);
+        }
+    }
+
+    private Track findTrackById(Long trackId) {
+        return trackRepository.findById(trackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+    }
+
+    private void validateTrackMemberMismatch(Track track, Member member) {
+        if (!track.getWishlist().getMember().getId().equals(member.getId())) {
+            throw new CustomException(ErrorCode.TRACK_MEMBER_MISMATCH);
         }
     }
 }

--- a/src/main/java/com/amcamp/domain/track/dao/TrackRepository.java
+++ b/src/main/java/com/amcamp/domain/track/dao/TrackRepository.java
@@ -1,0 +1,7 @@
+package com.amcamp.domain.track.dao;
+
+import com.amcamp.domain.track.domain.Track;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrackRepository extends JpaRepository<Track, Long> {
+}

--- a/src/main/java/com/amcamp/domain/track/dao/TrackRepository.java
+++ b/src/main/java/com/amcamp/domain/track/dao/TrackRepository.java
@@ -3,5 +3,8 @@ package com.amcamp.domain.track.dao;
 import com.amcamp.domain.track.domain.Track;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TrackRepository extends JpaRepository<Track, Long> {
+    List<Track> findAllByWishlistId(Long wishlistId);
 }

--- a/src/main/java/com/amcamp/domain/track/domain/Track.java
+++ b/src/main/java/com/amcamp/domain/track/domain/Track.java
@@ -1,0 +1,54 @@
+package com.amcamp.domain.track.domain;
+
+import com.amcamp.domain.common.model.BaseTimeEntity;
+import com.amcamp.domain.wishlist.domain.Wishlist;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Track extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "track_id")
+    private Long id;
+
+    private String artistName;
+
+    private String title;
+
+    private String albumName;
+
+    private String imageUrl;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "wishlist_id")
+    private Wishlist wishlist;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public Track(String artistName, String title, String albumName, String imageUrl, Wishlist wishlist) {
+        this.artistName = artistName;
+        this.title = title;
+        this.albumName = albumName;
+        this.imageUrl = imageUrl;
+        this.wishlist = wishlist;
+    }
+
+    public static Track createTrack(
+            String artistName, String title, String albumName, String imageUrl, Wishlist wishlist) {
+        return Track.builder()
+                .artistName(artistName)
+                .title(title)
+                .albumName(albumName)
+                .imageUrl(imageUrl)
+                .wishlist(wishlist)
+                .build();
+    }
+}

--- a/src/main/java/com/amcamp/domain/track/dto/request/TrackCreateRequest.java
+++ b/src/main/java/com/amcamp/domain/track/dto/request/TrackCreateRequest.java
@@ -1,0 +1,9 @@
+package com.amcamp.domain.track.dto.request;
+
+public record TrackCreateRequest(
+        Long wishlistId,
+        String artistName,
+        String title,
+        String albumName,
+        String imageUrl) {
+}

--- a/src/main/java/com/amcamp/domain/track/dto/response/TrackInfoResponse.java
+++ b/src/main/java/com/amcamp/domain/track/dto/response/TrackInfoResponse.java
@@ -1,0 +1,14 @@
+package com.amcamp.domain.track.dto.response;
+
+import com.amcamp.domain.track.domain.Track;
+
+public record TrackInfoResponse(
+        Long trackId,
+        String artistName,
+        String title,
+        String albumName,
+        String imageUrl) {
+    public static TrackInfoResponse from(Track track) {
+        return new TrackInfoResponse(track.getId(), track.getArtistName(), track.getTitle(), track.getAlbumName(), track.getImageUrl());
+    }
+}

--- a/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
 
     SPOTIFY_EXCEPTION(HttpStatus.SERVICE_UNAVAILABLE, "스포티파이 라이브러리 사용 중 예외가 발생했습니다."),
+
+    WISHLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "위시리스트를 찾을 수 없습니다."),
+    WISHLIST_MEMBER_MISMATCH(HttpStatus.FORBIDDEN, "위시리스트를 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/amcamp/global/error/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
 
     WISHLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "위시리스트를 찾을 수 없습니다."),
     WISHLIST_MEMBER_MISMATCH(HttpStatus.FORBIDDEN, "위시리스트를 생성한 유저와 로그인된 계정이 일치하지 않습니다"),
+
+    TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "트랙을 찾을 수 없습니다."),
+    TRACK_MEMBER_MISMATCH(HttpStatus.FORBIDDEN, "트랙을 생성한 유저와 로그인된 계정이 일치하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #45 

---
## 📌 작업 내용 및 특이사항

- 추천받은 곡을 위시리스트 내에 추가하고 삭제하고 조회하는 API를 구현하였습니다.

---
## 📚 참고사항

- 예외처리 꼼꼼하게 해주시기 바랍니다!